### PR TITLE
COMP: Fix undefined reference to Json symbols when compiled as Slicer extension

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,9 @@ else()
 
     generateCLP(SPV_SRCS_CLP ShapePopulationViewer.xml )
     add_executable( Launcher Launcher/Launcher.cxx ${SPV_SRCS_CLP} )
+    if(NOT "${DEFAULT_SEM_TARGET_LIBRARIES}" STREQUAL "")
+      target_link_libraries(Launcher ${DEFAULT_SEM_TARGET_LIBRARIES})
+    endif()
     install(TARGETS Launcher DESTINATION ${SlicerExecutionModel_DEFAULT_CLI_INSTALL_RUNTIME_DESTINATION} )
 endif()
 


### PR DESCRIPTION
This commit fixes a regression initially introduced by the addition of
ParameterSerializer support in Slicer (See Slicer/Slicer@0db89eb / r25337)

More specifically, it makes sure that Launcher is executable is properly
linked to "DEFAULT_SEM_TARGET_LIBRARIES" by reproducing the behavior of
"SEMMacroBuildCLI" macro.

Let's also note that "DEFAULT_SEM_TARGET_LIBRARIES" is set to "JsonCpp_LIBRARIES" when Slicer is build with
Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT set to ON.

Error fixes by this commit is the following:

[  1%] Linking CXX executable ../bin/Launcher
CMakeFiles/Launcher.dir/Launcher/Launcher.cxx.o: In function `main':
Launcher.cxx:(.text.startup+0x8ad): undefined reference to `Json::Value::Value(Json::ValueType)'
Launcher.cxx:(.text.startup+0x8bc): undefined reference to `Json::Reader::Reader()'
[...]

Reported-by: Clement Mirabel <mirclem@umich.edu>