### PR TITLE
ENH: CMakeLists: Also build as an extension if Slicer_DIR is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,10 +63,21 @@ endif()
 #                   Phase II: Build the ${LOCAL_PROJECT_NAME}, referencing the support
 #                             packages built in Phase I.
 #-----------------------------------------------------------------------------
-if( ShapePopulationViewer_BUILD_SLICER_EXTENSION )
-  set(${LOCAL_PROJECT_NAME}_SUPERBUILD OFF CACHE STRING "Build ${LOCAL_PROJECT_NAME} and the projects it depends on via SuperBuild.cmake.")
+
+set(_default ON)
+if(${LOCAL_PROJECT_NAME}_BUILD_SLICER_EXTENSION)
+  set(_default OFF)
 endif()
-option(${LOCAL_PROJECT_NAME}_SUPERBUILD "Build ${LOCAL_PROJECT_NAME} and the projects it depends on via SuperBuild.cmake." ON)
+
+option(${LOCAL_PROJECT_NAME}_SUPERBUILD "Build ${LOCAL_PROJECT_NAME} and the projects it depends on via SuperBuild.cmake." ${_default})
+
+set(_msg "Checking if enabling Superbuild")
+message(STATUS ${_msg})
+if(${LOCAL_PROJECT_NAME}_SUPERBUILD)
+  message(STATUS "${_msg} - yes")
+else()
+  message(STATUS "${_msg} - no")
+endif()
 
 #-----------------------------------------------------------------------------
 # Superbuild script

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,31 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/Common.cmake)
 ## two completely independant CMake build environments.
 
 #-----------------------------------------------------------------------------
+# Standalone vs Slicer extension option
+#
+
+# This option should be named after the project name, it corresponds to the
+# option set to ON when the project is build by the Slicer Extension build
+# system.
+
+set(_default OFF)
+set(_reason "${LOCAL_PROJECT_NAME}_BUILD_SLICER_EXTENSION is ON")
+if(NOT DEFINED ${LOCAL_PROJECT_NAME}_BUILD_SLICER_EXTENSION AND DEFINED Slicer_DIR)
+  set(_default ON)
+  set(_reason "Slicer_DIR is SET")
+endif()
+
+option(${LOCAL_PROJECT_NAME}_BUILD_SLICER_EXTENSION "Build as a Slicer Extension" ${_default})
+
+set(_msg "Checking if building as a Slicer extension")
+message(STATUS ${_msg})
+if(${LOCAL_PROJECT_NAME}_BUILD_SLICER_EXTENSION)
+  message(STATUS "${_msg} - yes (${_reason})")
+else()
+  message(STATUS "${_msg} - no (${LOCAL_PROJECT_NAME}_BUILD_SLICER_EXTENSION is OFF)")
+endif()
+
+#-----------------------------------------------------------------------------
 # Superbuild Option - Enabled by default
 #                   Phase I:  ${LOCAL_PROJECT_NAME}_SUPERBUILD is set to ON, and the
 #                             supporting packages defined in "SuperBuild.cmake"


### PR DESCRIPTION
This PR proposes improvements for the message displayed at configuration time.

For example:

* By default:

```
[...]
-- Checking if building as a Slicer extension
-- Checking if building as a Slicer extension - no (ShapePopulationViewer_BUILD_SLICER_EXTENSION is OFF)
-- Checking if enabling Superbuild
-- Checking if enabling Superbuild - yes
[...]
```

* When only `-DSlicer_DIR:PATH=/path/to/Slicer-SuperBuild/Slicer-build` is passed ... 

```
-- Checking if building as a Slicer extension
-- Checking if building as a Slicer extension - yes (Slicer_DIR is SET)
-- Checking if enabling Superbuild
-- Checking if enabling Superbuild - no
```

* And when `ShapePopulationViewer_BUILD_SLICER_EXTENSION ` is set ... 

```
-- Checking if building as a Slicer extension
-- Checking if building as a Slicer extension - yes (ShapePopulationViewer_BUILD_SLICER_EXTENSION is ON)
-- Checking if enabling Superbuild
-- Checking if enabling Superbuild - no

```