### PR TITLE
COMP: Update minimum required CMake version to match Slicer requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
-cmake_policy(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(ShapePopulationViewer)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,5 @@
 # --- cmake -------------------------------------------------------------------------------
-cmake_minimum_required(VERSION 2.8.3)
-if(COMMAND CMAKE_POLICY)
-  cmake_policy(SET CMP0003 NEW)
-endif()
+cmake_minimum_required(VERSION 3.5)
 
 # --- INCLUDES ----------------------------------------------------------------------------
 find_package(SlicerExecutionModel REQUIRED)

--- a/src/Testing/CMakeLists.txt
+++ b/src/Testing/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.8.3)
 
 # Add external data from midas
 list(APPEND ExternalData_URL_TEMPLATES


### PR DESCRIPTION
This commit updates the required version to 3.5

Co-authored-by: Jean-Christophe Fillion-Robin <JChris.FillionR@kitware.com>