### PR TITLE
COMP: Add support for building with Qt5 and VTK9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,25 @@ else()
 endif()
 
 #-----------------------------------------------------------------------------
+# Qt
+# 
+# If building as a Slicer extension, use Slicer's Qt Version
+# Otherwise, default to Qt4
+#-----------------------------------------------------------------------------
+
+set(_qt_version "4")
+
+if (${LOCAL_PROJECT_NAME}_BUILD_SLICER_EXTENSION)
+  find_package(Slicer REQUIRED)
+  if (Slicer_REQUIRED_QT_VERSION VERSION_GREATER "4.9")
+    set(_qt_version "5")
+  endif()
+endif()
+
+SET(ShapePopulationViewer_QT_VERSION ${_qt_version} CACHE STRING "Version of Qt to use")
+SET_PROPERTY(CACHE ShapePopulationViewer_QT_VERSION PROPERTY STRINGS 4 5)
+
+#-----------------------------------------------------------------------------
 # Superbuild Option - Enabled by default
 #                   Phase I:  ${LOCAL_PROJECT_NAME}_SUPERBUILD is set to ON, and the
 #                             supporting packages defined in "SuperBuild.cmake"

--- a/ShapePopulationViewer.cmake
+++ b/ShapePopulationViewer.cmake
@@ -19,14 +19,21 @@ if( ShapePopulationViewer_BUILD_SLICER_EXTENSION )
   resetForSlicer( NAMES CMAKE_C_COMPILER CMAKE_CXX_COMPILER CMAKE_CXX_FLAGS CMAKE_C_FLAGS )
 endif()
 
-find_package(Qt4 REQUIRED)
+if(ShapePopulationViewer_QT_VERSION VERSION_EQUAL "4")
+  find_package(Qt4 REQUIRED)
+  include(${QT_USE_FILE})
+  set(ShapePopulationViewer_VTK_USE_QVTKOPENGLWIDGET 0)
+else()
+  find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
+  if (VTK_VERSION VERSION_GREATER "7" AND VTK_RENDERING_BACKEND STREQUAL "OpenGL2")
+    set(ShapePopulationViewer_VTK_USE_QVTKOPENGLWIDGET 1)
+  endif()
+endif()
 
-include(${QT_USE_FILE})
 if( BUILD_TESTING )
   include(CTest)
   include(ExternalData)
 endif()
-
 
 add_subdirectory(src)
 

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -57,8 +57,12 @@ endif()
 # Superbuild option(s)
 #-----------------------------------------------------------------------------
 
-find_package(Qt4 REQUIRED)
-include(${QT_USE_FILE})
+if(ShapePopulationViewer_QT_VERSION VERSION_EQUAL "4")
+  find_package(Qt4 REQUIRED)
+  include(${QT_USE_FILE})
+else()
+  find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
+endif()
 
 option(USE_SYSTEM_ITK "Build using an externally defined version of ITK" OFF)
 option(USE_SYSTEM_SlicerExecutionModel "Build using an externally defined version of SlicerExecutionModel"  OFF)

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -75,7 +75,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
         )
   # endif()
   list(APPEND EXTERNAL_PROJECT_OPTIONAL_ARGS
-      #-DDESIRED_QT_VERSION:STRING=4 # Unused
+      -DVTK_QT_VERSION:STRING=${ShapePopulationViewer_QT_VERSION}
       -DVTK_USE_QT:BOOL=ON
       -DVTK_USE_QVTK_QTOPENGL:BOOL=ON
       -DVTK_USE_GUISUPPORT:BOOL=ON

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,14 +13,23 @@ if( ${index} EQUAL -1)
   add_definitions("-DSPV_EXTENSION=1")
 endif()
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ShapePopulationBase.h.in ${CMAKE_CURRENT_SOURCE_DIR}/ShapePopulationBase.h)
+
 # --- SRCS --------------------------------------------------------------------------------
 file(GLOB CXX_FILES *.cxx)
 file(GLOB UI_FILES *.ui)
 file(GLOB QT_WRAP *QT.h)
 file(GLOB QT_QRC_FILES *.qrc)
-QT4_WRAP_UI(UISrcs ${UI_FILES})
-QT4_WRAP_CPP(MOCSrcs ${QT_WRAP})
-QT4_ADD_RESOURCES(QRCrcs ${QT_QRC_FILES})
+
+if(ShapePopulationViewer_QT_VERSION VERSION_EQUAL "4")
+  QT4_WRAP_UI(UISrcs ${UI_FILES})
+  QT4_WRAP_CPP(MOCSrcs ${QT_WRAP})
+  QT4_ADD_RESOURCES(QRCrcs ${QT_QRC_FILES})
+else()
+  QT5_WRAP_UI(UISrcs ${UI_FILES})
+  QT5_WRAP_CPP(MOCSrcs ${QT_WRAP})
+  QT5_ADD_RESOURCES(QRCrcs ${QT_QRC_FILES})
+endif()
 
 # --- LIBRARIES ---------------------------------------------------------------------------
 if(VTK_LIBRARIES)

--- a/src/ShapePopulationBase.h.in
+++ b/src/ShapePopulationBase.h.in
@@ -38,6 +38,8 @@
 
 #include <set>
 
+#cmakedefine ShapePopulationViewer_VTK_USE_QVTKOPENGLWIDGET
+
 class ShapePopulationBase
 {
     friend class TestShapePopulationBase;

--- a/src/ShapePopulationQT.cxx
+++ b/src/ShapePopulationQT.cxx
@@ -124,7 +124,11 @@ ShapePopulationQT::ShapePopulationQT()
     QStandardItemModel * model = new QStandardItemModel(0,2,this);
     tableView->setModel(model);
     tableView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+    tableView->horizontalHeader()->setSectionResizeMode(QHeaderView::Fixed);
+#else
     tableView->horizontalHeader()->setResizeMode(QHeaderView::Fixed);
+#endif
     tableView->setSelectionBehavior(QAbstractItemView::SelectRows);
     
     //Display
@@ -941,7 +945,7 @@ void ShapePopulationQT::CreateWidgets()
     /* QT WIDGETS */
     for (int i = m_numberOfMeshes; i < m_fileList.size(); i++)
     {
-        QVTKWidget *meshWidget = new QVTKWidget(this->scrollAreaWidgetContents);
+        VTKWidgetType *meshWidget = new VTKWidgetType(this->scrollAreaWidgetContents);
         m_widgetList.push_back(meshWidget);
         meshWidget->GetRenderWindow()->AddRenderer(m_windowsList.at(i)->GetRenderers()->GetFirstRenderer());
         meshWidget->GetInteractor()->AddObserver(vtkCommand::LeftButtonPressEvent, this, &ShapePopulationQT::ClickEvent);

--- a/src/ShapePopulationQT.h
+++ b/src/ShapePopulationQT.h
@@ -14,7 +14,11 @@
 
 // QT
 #include <QMainWindow>
+#ifdef ShapePopulationViewer_VTK_USE_QVTKOPENGLWIDGET
+#include <QVTKOpenGLWidget.h>
+#else
 #include <QVTKWidget.h>
+#endif
 #include <QFileDialog>              //Open directory/files
 #include <QFileInfo>                //Use Files
 #include <QKeyEvent>                //KeyPressEvent
@@ -22,6 +26,7 @@
 #include <QColorDialog>             //ColorPicker
 #include <vtkDelimitedTextReader.h> //CSVloader
 #include <QUrl>                     //DropFiles
+#include <QMimeData>
 
 #include <vtkOrientationMarkerWidget.h>
 
@@ -60,7 +65,12 @@ protected:
     QString m_exportDirectory;
     QString m_pathSphere;
     QFileInfoList m_fileList;
-    std::vector<QVTKWidget *> m_widgetList;
+#ifdef ShapePopulationViewer_VTK_USE_QVTKOPENGLWIDGET
+    typedef QVTKOpenGLWidget VTKWidgetType;
+#else
+    typedef QVTKWidget VTKWidgetType;
+#endif
+    std::vector<VTKWidgetType *> m_widgetList;
     cameraDialogQT * m_cameraDialog;
     backgroundDialogQT * m_backgroundDialog;
     CSVloaderQT * m_CSVloaderDialog;

--- a/src/customizeColorMapByDirectionDialogQT.cxx
+++ b/src/customizeColorMapByDirectionDialogQT.cxx
@@ -132,7 +132,7 @@ void customizeColorMapByDirectionDialogQT::AxisColor()
     renderer->SetBackground(m_backgroundColor);
     renderer->ResetCamera();
 
-    widget = new QVTKWidget(ui->widget_AxisColor);
+    widget = new VTKWidgetType(ui->widget_AxisColor);
     widget->resize(500,350);
     widget->SetRenderWindow(renderWindow);
     widget->setDisabled(true);

--- a/src/customizeColorMapByDirectionDialogQT.h
+++ b/src/customizeColorMapByDirectionDialogQT.h
@@ -1,6 +1,9 @@
 #ifndef CUSTOMIZECOLORMAPBYDIRECTIONDIALOGQT_H
 #define CUSTOMIZECOLORMAPBYDIRECTIONDIALOGQT_H
 
+#include "ShapePopulationBase.h"
+#include "axisColorStruct.h"
+
 #include <QDialog>
 #include <vtkSmartPointer.h>
 #include <vtkPolyData.h>
@@ -20,13 +23,13 @@
 #include <vtkTextProperty.h>
 #include <vtkTextActor.h>
 #include <iostream>
+#ifdef ShapePopulationViewer_VTK_USE_QVTKOPENGLWIDGET
+#include <QVTKOpenGLWidget.h>
+#else
 #include <QVTKWidget.h>
+#endif
 #include <QColorDialog>
 #include <QFrame>
-
-#include "ShapePopulationBase.h"
-#include "axisColorStruct.h"
-
 
 namespace Ui {
 class customizeColorMapByDirectionDialogQT;
@@ -44,7 +47,12 @@ public:
 protected:
     std::vector< vtkSmartPointer<vtkActor> > m_arrowActors;
     std::vector< vtkSmartPointer<vtkTextActor> > m_labelActors;
-    QVTKWidget * widget;
+#ifdef ShapePopulationViewer_VTK_USE_QVTKOPENGLWIDGET
+    typedef QVTKOpenGLWidget VTKWidgetType;
+#else
+    typedef QVTKWidget VTKWidgetType;
+#endif
+    VTKWidgetType * widget;
     bool m_sameColor;
     bool m_complementaryColor;
     std::vector< QFrame* > m_frameAxis;


### PR DESCRIPTION
This will allow building with newer versions of Slicer, and most of these changes are either based on or lifted directly from Slicer.

I have not tested these changes with a stand-alone build.