### PR TITLE
ENH: Allow to control vector display from Python

### DIFF
--- a/src/qSlicerShapePopulationViewerModuleWidget.cxx
+++ b/src/qSlicerShapePopulationViewerModuleWidget.cxx
@@ -280,6 +280,21 @@ void qSlicerShapePopulationViewerModuleWidget::deleteModels()
     d->ShapePopulationWidget->actionDelete_All->trigger();
 }
 
+void qSlicerShapePopulationViewerModuleWidget::setVectorScale(double value){
+    Q_D(qSlicerShapePopulationViewerModuleWidget);
+    d->ShapePopulationWidget->slider_vectorScale->setValue((int) (value * 100));
+}
+
+void qSlicerShapePopulationViewerModuleWidget::setVectorDensity(double value){
+    Q_D(qSlicerShapePopulationViewerModuleWidget);
+    d->ShapePopulationWidget->slider_arrowDens->setValue((int) (value * 100));
+}
+
+void qSlicerShapePopulationViewerModuleWidget::displayVectors(bool display){
+    Q_D(qSlicerShapePopulationViewerModuleWidget);
+    d->ShapePopulationWidget->checkBox_displayVectors->setChecked(display);
+}
+
 //-----------------------------------------------------------------------------
 void qSlicerShapePopulationViewerModuleWidget::onMRMLSceneNodeAddedEvent(vtkObject *vtkNotUsed(caller), vtkObject *callData)
 {

--- a/src/qSlicerShapePopulationViewerModuleWidget.h
+++ b/src/qSlicerShapePopulationViewerModuleWidget.h
@@ -56,6 +56,10 @@ public slots:
 
     void deleteModels();
 
+    void setVectorScale(double value);
+    void setVectorDensity(double value);
+    void displayVectors(bool display);
+
 protected slots:
     void onMRMLSceneNodeAddedEvent(vtkObject*,vtkObject*);
     void onMRMLNodeModified(vtkObject*);


### PR DESCRIPTION
Allows enable/disable vector display options from Python, as in:

```python
spv = slicer.modules.shapepopulationviewer.widgetRepresentation()
spv.vectorDisplay(True)
spv.setVectorScale(1.2)
spv.setVectorDensity(0.9)
```

Intended to improve implementation of https://github.com/slicersalt/SlicerDWD/issues/1

---

Really, most of the display options could be exposed this way, but wanted to keep this PR limited in scope and get review on the approach. 

I experimented with using `ShapePopulationBase::setVectorScale`, `ShapePopulationBase::setVectorDensity`, etc. However since various rendering events need to be properly invoked and that approach was more bug-prone, instead I programmatically set the corresponding widgets in the UI. This ensures all the appropriate events are invoked and SPV can keep itself synchronized.
