### PR TITLE
BUG: Use correct filter for reducing number of vectors

### DIFF
--- a/src/ShapePopulationBase.cxx
+++ b/src/ShapePopulationBase.cxx
@@ -937,10 +937,9 @@ void ShapePopulationBase::setVectorDensity(double value)
         m_vectorDensity[m_selectedIndex[i]] = value;
 
         ShapePopulationData * mesh = m_meshList[m_selectedIndex[i]];
-        vtkSmartPointer<vtkMaskPoints> filter = vtkSmartPointer<vtkMaskPoints>::New();
+        vtkSmartPointer<vtkDecimatePro> filter = vtkSmartPointer<vtkDecimatePro>::New();
         filter->SetInputData(mesh->GetPolyData());
-        filter->SetOnRatio(101-value);
-
+        filter->SetTargetReduction(1 - value/100);
 
         vtkGlyph3D* glyph = m_glyphList[m_selectedIndex[i]];
         glyph->SetInputConnection(filter->GetOutputPort());

--- a/src/ShapePopulationBase.h
+++ b/src/ShapePopulationBase.h
@@ -32,7 +32,7 @@
 
 #include "vtkGlyph3D.h"
 #include "vtkArrowSource.h"
-#include "vtkMaskPoints.h"
+#include "vtkDecimatePro.h"
 
 #include <set>
 


### PR DESCRIPTION
vtkMaskPoints is used to show every nth point which is inconsistent with the current UI that allows selection of a percentage of the original data.